### PR TITLE
インクリメンタルサーチの実装

### DIFF
--- a/app/assets/javascripts/users.js
+++ b/app/assets/javascripts/users.js
@@ -1,0 +1,65 @@
+$(function() {
+  function addUser(user) {
+    let html = `
+                <div class="ChatMember">
+                  <p class="ChatMember__name">${user.name}</p>
+                  <div class="ChatMember__add ChatMember__button" data-user-id="${user.id}" data-user-name="${user.name}">追加</div>
+                </div>
+                `;
+    $("#UserSearchResult").append(html);
+  }
+
+  function addNoUser() {
+    let html = `
+                <div class="ChatMember">
+                  <p class="ChatMember__name">ユーザーが見つかりません</p>
+                </div>
+                `;
+    $("#UserSearchResult").append(html);
+  }
+
+  function addMember(name, id) {
+    let html = `
+                <div class="ChatMember">
+                  <p class="ChatMember__name">${name}</p>
+                  <input name="group[user_ids][]" type="hidden" value="${id}" />
+                  <div class="ChatMember__remove ChatMember__button">削除</div>
+                </div>
+                `;
+    $(".ChatMembers").append(html);
+  }
+  
+  $("#UserSearch__field").on("keyup", function() {
+    let input = $("#UserSearch__field").val();
+    $.ajax({
+      type: "GET",
+      url: "/users",
+      data: { keyword: input },
+      dataType: "json"
+    })
+    .done(function(users) {
+      $("#UserSearchResult").empty();
+      if (users.length !== 0) {
+        users.forEach(function(user) {
+          addUser(user);
+        });
+      } else if (input.length == 0) {
+        return false;
+      } else {
+        addNoUser();
+      }
+    })
+    .fail(function() {
+      alert("通信エラーです。ユーザーが表示できません。");
+    });
+  });
+  $("#UserSearchResult").on("click", ".ChatMember__add", function() {
+    const userName = $(this).attr("data-user-name");
+    const userId = $(this).attr("data-user-id");
+    $(this).parent().remove();
+    addMember(userName, userId);
+  });
+  $(".ChatMembers").on("click", ".ChatMember__remove", function() {
+    $(this).parent().remove();
+  });
+});

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,14 @@
 class UsersController < ApplicationController
 
+  def index
+    return nil if params[:keyword] == ""
+    @users = User.where(['name LIKE ?', "%#{params[:keyword]}%"] ).where.not(id: current_user.id).limit(10)
+    respond_to do |format|
+      format.html
+      format.json
+    end
+  end
+
   def edit
   end
 

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -14,9 +14,24 @@
     .SettingGroupForm__leftField
       %label.SettingGroupForm__label チャットメンバーを追加
     .SettingGroupForm__rightField
-      / グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください
-      = f.collection_check_boxes :user_ids, User.all, :id, :name
-      / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
+      .UserSearch
+        %input#UserSearch__field.SettingGroupForm__input{placeholder: "追加したいユーザー名を入力してください", type: "text"}/
+      #UserSearchResult
+  .SettingGroupForm__field
+    .SettingGroupForm__leftField
+      = f.label :name, value: "チャットメンバー", class: "SettingGroupForm__label"
+    .SettingGroupForm__rightField
+      .ChatMembers
+        .ChatMember
+          %p.ChatMember__name= current_user.name
+          %input{name: "group[user_ids][]", type: "hidden", value: current_user.id}
+        - group.users.each do |user|
+          - if current_user.name != user.name
+            .ChatMember
+              %p.ChatMember__name 
+                = user.name
+              .ChatMember__remove.ChatMember__button{"data-user-id": user.id, "data-user-name": user.name} 削除
+              %input{name: "group[user_ids][]", type:"hidden", value: user.id}
   .SettingGroupForm__field
     .SettingGroupForm__leftField
     .SettingGroupForm__rightField

--- a/app/views/users/index.json.jbuilder
+++ b/app/views/users/index.json.jbuilder
@@ -1,0 +1,4 @@
+json.array! @users do |user|
+  json.id user.id
+  json.name user.name
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   devise_for :users
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   root 'groups#index'
-  resources :users, only: [:edit, :update]
+  resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
   end


### PR DESCRIPTION
# What
　インクリメンタルサーチの実装を次の順番に行った。
　API側の準備、テキストフィールドの作成とイベント発火の設定、イベント時に非同期通信がでいるように、非同期通信の結果からHTMLの作成しビューに追加、エラー時の処理。
　追加したいユーザーを選択し、DBに保存されるように、追加ボタンを押される→チャットメンバー欄に追加される→更新するボタンを押すとサーバー側に送られるように実装した。

# Why
　チャットグループ編集画面や検索を見やすく使いやすいようにすることは、利用者にとって必要なことだから。
　